### PR TITLE
Support optional custom caching objects in fetchAndCache

### DIFF
--- a/api.js
+++ b/api.js
@@ -9,7 +9,8 @@ export class API {
    */
   constructor(options = {}) {
     this.options = options
-    this.cache = {}
+    this.cache = options.cache || new Map()
+    this.inFlight = {}
   }
 
   /**
@@ -126,23 +127,62 @@ export class API {
     }
     let key = url
     // console.log('fetchAndCache', key)
-    if (Object.hasOwn(this.cache, key)) {
-      let r = await this.cache[key]
-      // console.log('in cache', key, r)
+
+    if (this.inFlight[key]) {
+      let r = await this.inFlight[key]
       if (r instanceof Error) {
         throw r
       }
       return r
     }
+
+    const hasMethods = typeof this.cache.get === 'function' && typeof this.cache.set === 'function'
+
+    let p = (async () => {
+      if (hasMethods) {
+        let cached = await this.cache.get(key)
+        if (cached !== undefined && cached !== null) {
+          return cached
+        }
+      } else {
+        if (Object.hasOwn(this.cache, key)) {
+          return this.cache[key]
+        }
+      }
+
+      let fetchPromise = this.fetch(url, options)
+      if (!hasMethods) {
+        this.cache[key] = fetchPromise
+      }
+
+      try {
+        let r = await fetchPromise
+        if (hasMethods) {
+          await this.cache.set(key, r)
+        } else {
+          this.cache[key] = r
+        }
+        return r
+      } catch (e) {
+        if (hasMethods) {
+          await this.cache.set(key, e)
+        } else {
+          this.cache[key] = e
+        }
+        throw e
+      }
+    })()
+
+    this.inFlight[key] = p
+
     try {
-      let p = this.fetch(url, options)
-      this.cache[key] = p
       let r = await p
+      if (r instanceof Error) {
+        throw r
+      }
       return r
-    } catch (e) {
-      // also going to cache exceptions too. They should hopefully be APIError's
-      this.cache[key] = e
-      throw e
+    } finally {
+      delete this.inFlight[key]
     }
   }
 }
@@ -160,6 +200,9 @@ let apiURL = defaultAPI.options.apiURL
 export function apiInit(options = {}) {
   defaultAPI.options = options
   apiURL = options.apiURL
+  if (options.cache) {
+    defaultAPI.cache = options.cache
+  }
 }
 
 export function getCookie(name) {

--- a/api.js
+++ b/api.js
@@ -136,39 +136,20 @@ export class API {
       return r
     }
 
-    const hasMethods = typeof this.cache.get === 'function' && typeof this.cache.set === 'function'
-
     let p = (async () => {
-      if (hasMethods) {
-        let cached = await this.cache.get(key)
-        if (cached !== undefined) {
-          return cached
-        }
-      } else {
-        if (Object.hasOwn(this.cache, key)) {
-          return this.cache[key]
-        }
+      let cached = await this.cache.get(key)
+      if (cached !== undefined) {
+        return cached
       }
 
       let fetchPromise = this.fetch(url, options)
-      if (!hasMethods) {
-        this.cache[key] = fetchPromise
-      }
 
       try {
         let r = await fetchPromise
-        if (hasMethods) {
-          await this.cache.set(key, r)
-        } else {
-          this.cache[key] = r
-        }
+        await this.cache.set(key, r)
         return r
       } catch (e) {
-        if (hasMethods) {
-          await this.cache.set(key, e)
-        } else {
-          this.cache[key] = e
-        }
+        await this.cache.set(key, e)
         throw e
       }
     })()

--- a/api.js
+++ b/api.js
@@ -138,7 +138,20 @@ export class API {
 
     let p = (async () => {
       let cached = await this.cache.get(key)
-      if (cached !== undefined) {
+      if (cached !== undefined && cached !== null) {
+        if (cached && typeof cached === 'object' && ('value' in cached || 'error' in cached)) {
+          if ('error' in cached) {
+            let errObj = cached.error
+            let e = new APIError(errObj.message, { status: errObj.status, data: errObj.data })
+            if (errObj.name) e.name = errObj.name
+            if (errObj.stack) e.stack = errObj.stack
+            throw e
+          }
+          return cached.value
+        }
+        if (cached instanceof Error) {
+          throw cached
+        }
         return cached
       }
 
@@ -146,10 +159,17 @@ export class API {
 
       try {
         let r = await fetchPromise
-        await this.cache.set(key, r)
+        await this.cache.set(key, { value: r })
         return r
       } catch (e) {
-        await this.cache.set(key, e)
+        let errObj = {
+          message: e.message,
+          status: e.status,
+          data: e.data,
+          name: e.name,
+          stack: e.stack
+        }
+        await this.cache.set(key, { error: errObj })
         throw e
       }
     })()

--- a/api.js
+++ b/api.js
@@ -10,7 +10,7 @@ export class API {
   constructor(options = {}) {
     this.options = options
     this.cache = options.cache || new Map()
-    this.inFlight = {}
+    this.inFlight = new Map()
   }
 
   /**
@@ -128,8 +128,8 @@ export class API {
     let key = url
     // console.log('fetchAndCache', key)
 
-    if (this.inFlight[key]) {
-      let r = await this.inFlight[key]
+    if (this.inFlight.has(key)) {
+      let r = await this.inFlight.get(key)
       if (r instanceof Error) {
         throw r
       }
@@ -154,7 +154,7 @@ export class API {
       }
     })()
 
-    this.inFlight[key] = p
+    this.inFlight.set(key, p)
 
     try {
       let r = await p
@@ -163,7 +163,7 @@ export class API {
       }
       return r
     } finally {
-      delete this.inFlight[key]
+      this.inFlight.delete(key)
     }
   }
 }

--- a/api.js
+++ b/api.js
@@ -141,7 +141,7 @@ export class API {
     let p = (async () => {
       if (hasMethods) {
         let cached = await this.cache.get(key)
-        if (cached !== undefined && cached !== null) {
+        if (cached !== undefined) {
           return cached
         }
       } else {

--- a/api.js
+++ b/api.js
@@ -141,18 +141,24 @@ export class API {
       if (cached !== undefined && cached !== null) {
         if (cached && typeof cached === 'object' && ('value' in cached || 'error' in cached)) {
           if ('error' in cached) {
-            let errObj = cached.error
-            let e = new APIError(errObj.message, { status: errObj.status, data: errObj.data })
-            if (errObj.name) e.name = errObj.name
-            if (errObj.stack) e.stack = errObj.stack
-            throw e
+            if (cached.expiresAt && Date.now() > cached.expiresAt) {
+              await this.cache.delete(key)
+              // fall through to fetch again
+            } else {
+              let errObj = cached.error
+              let e = new APIError(errObj.message, { status: errObj.status, data: errObj.data })
+              if (errObj.name) e.name = errObj.name
+              if (errObj.stack) e.stack = errObj.stack
+              throw e
+            }
+          } else {
+            return cached.value
           }
-          return cached.value
-        }
-        if (cached instanceof Error) {
+        } else if (cached instanceof Error) {
           throw cached
+        } else {
+          return cached
         }
-        return cached
       }
 
       let fetchPromise = this.fetch(url, options)
@@ -162,14 +168,17 @@ export class API {
         await this.cache.set(key, { value: r })
         return r
       } catch (e) {
-        let errObj = {
-          message: e.message,
-          status: e.status,
-          data: e.data,
-          name: e.name,
-          stack: e.stack
+        let errorTTL = (options && options.errorTTL !== undefined) ? options.errorTTL : (this.options.errorTTL !== undefined ? this.options.errorTTL : 10)
+        if (errorTTL > 0) {
+          let errObj = {
+            message: e.message,
+            status: e.status,
+            data: e.data,
+            name: e.name,
+            stack: e.stack
+          }
+          await this.cache.set(key, { error: errObj, expiresAt: Date.now() + errorTTL * 1000 })
         }
-        await this.cache.set(key, { error: errObj })
         throw e
       }
     })()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "api",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "api",
-      "version": "1.0.6",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "testkit": "github:treeder/testkit"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "type": "module",
   "description": "Like fetch, but better. Parses JSON, stringifies and handles errors.",
   "main": "api.js",

--- a/test/cache.js
+++ b/test/cache.js
@@ -152,6 +152,60 @@ export async function testCache(c) {
       assert(fetchCount === 1)
     }
 
+    // 6. Test persistent custom cache (JSON serialization / deserialization)
+    {
+      fetchCount = 0
+      const store = new Map()
+      const persistentCache = {
+        get: async (key) => {
+          let val = store.get(key)
+          return val !== undefined ? JSON.parse(val) : undefined
+        },
+        set: async (key, val) => {
+          store.set(key, JSON.stringify(val))
+        },
+        delete: async (key) => {
+          store.delete(key)
+        }
+      }
+
+      const api = new API({ cache: persistentCache })
+
+      // Successful fetch
+      let res1 = await api.fetchAndCache('https://example.com/api/persistent')
+      assert(res1.count === 1)
+      assert(fetchCount === 1)
+
+      // Cached successful fetch
+      let res2 = await api.fetchAndCache('https://example.com/api/persistent')
+      assert(res2.count === 1)
+      assert(fetchCount === 1)
+
+      // Failed fetch
+      let errorThrown = false
+      try {
+        await api.fetchAndCache('https://example.com/api/fail-persistent')
+      } catch (e) {
+        errorThrown = true
+        assert(e.status === 500)
+        assert(e.message !== '')
+      }
+      assert(errorThrown === true)
+      assert(fetchCount === 2)
+
+      // Second call to failed (should retrieve from persistent cache, deserialize and throw error)
+      errorThrown = false
+      try {
+        await api.fetchAndCache('https://example.com/api/fail-persistent')
+      } catch (e) {
+        errorThrown = true
+        assert(e.status === 500)
+        assert(e.message !== '')
+      }
+      assert(errorThrown === true)
+      assert(fetchCount === 2)
+    }
+
   } finally {
     // Restore original fetch
     globalThis.fetch = originalFetch

--- a/test/cache.js
+++ b/test/cache.js
@@ -206,6 +206,45 @@ export async function testCache(c) {
       assert(fetchCount === 2)
     }
 
+    // 7. Test errorTTL (expiry of cached errors)
+    {
+      fetchCount = 0
+      const api = new API()
+
+      // First call fails, we set a short 1 second TTL
+      let errorThrown = false
+      try {
+        await api.fetchAndCache('https://example.com/api/fail', { errorTTL: 1 })
+      } catch (e) {
+        errorThrown = true
+      }
+      assert(errorThrown === true)
+      assert(fetchCount === 1)
+
+      // Second call (within TTL) should throw immediately without refetching
+      errorThrown = false
+      try {
+        await api.fetchAndCache('https://example.com/api/fail')
+      } catch (e) {
+        errorThrown = true
+      }
+      assert(errorThrown === true)
+      assert(fetchCount === 1)
+
+      // Wait 1.1 seconds for error TTL to expire
+      await new Promise(resolve => setTimeout(resolve, 1100))
+
+      // Third call should attempt to fetch again (since cached error expired)
+      errorThrown = false
+      try {
+        await api.fetchAndCache('https://example.com/api/fail')
+      } catch (e) {
+        errorThrown = true
+      }
+      assert(errorThrown === true)
+      assert(fetchCount === 2)
+    }
+
   } finally {
     // Restore original fetch
     globalThis.fetch = originalFetch

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,145 @@
+import { assert } from 'testkit'
+import { API } from '../api.js'
+
+export async function testCache(c) {
+  // Save original fetch
+  const originalFetch = globalThis.fetch
+
+  try {
+    // 1. Mock fetch
+    let fetchCount = 0
+    globalThis.fetch = async (url, options) => {
+      fetchCount++
+      if (url.includes('fail')) {
+        return {
+          ok: false,
+          status: 500,
+          headers: {
+            get: (name) => name.toLowerCase() === 'content-type' ? 'application/json' : null
+          },
+          json: async () => ({ error: 'failed' })
+        }
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: {
+          get: (name) => name.toLowerCase() === 'content-type' ? 'application/json' : null
+        },
+        json: async () => ({ data: 'success', count: fetchCount })
+      }
+    }
+
+    // 2. Test Default Caching behavior
+    {
+      fetchCount = 0
+      const api = new API()
+      assert(api.cache instanceof Map)
+      
+      let res1 = await api.fetchAndCache('https://example.com/api/test')
+      assert(res1.count === 1)
+      assert(fetchCount === 1)
+
+      // Second call should be cached
+      let res2 = await api.fetchAndCache('https://example.com/api/test')
+      assert(res2.count === 1)
+      assert(fetchCount === 1)
+
+      // Test caching errors
+      let errorThrown = false
+      try {
+        await api.fetchAndCache('https://example.com/api/fail')
+      } catch (e) {
+        errorThrown = true
+      }
+      assert(errorThrown === true)
+      assert(fetchCount === 2)
+
+      // Second call to failed should also hit cache and throw without fetching again
+      errorThrown = false
+      try {
+        await api.fetchAndCache('https://example.com/api/fail')
+      } catch (e) {
+        errorThrown = true
+      }
+      assert(errorThrown === true)
+      assert(fetchCount === 2)
+    }
+
+    // 3. Test Custom Caching behavior
+    {
+      fetchCount = 0
+      const store = new Map()
+      const mockCache = {
+        get: async (key) => store.get(key),
+        set: async (key, val) => { store.set(key, val) },
+        delete: async (key) => { store.delete(key) }
+      }
+
+      const api = new API({ cache: mockCache })
+
+      let res1 = await api.fetchAndCache('https://example.com/api/test-custom')
+      assert(res1.count === 1)
+      assert(fetchCount === 1)
+      assert(store.has('https://example.com/api/test-custom'))
+
+      // Second call should come from the custom cache
+      let res2 = await api.fetchAndCache('https://example.com/api/test-custom')
+      assert(res2.count === 1)
+      assert(fetchCount === 1)
+
+      // Delete from cache and verify it refetches
+      await mockCache.delete('https://example.com/api/test-custom')
+      let res3 = await api.fetchAndCache('https://example.com/api/test-custom')
+      assert(res3.count === 2)
+      assert(fetchCount === 2)
+
+      // Test caching errors in custom cache
+      let errorThrown = false
+      try {
+        await api.fetchAndCache('https://example.com/api/fail-custom')
+      } catch (e) {
+        errorThrown = true
+      }
+      assert(errorThrown === true)
+      assert(fetchCount === 3)
+      assert(store.has('https://example.com/api/fail-custom'))
+
+      // Second call to failed should throw without fetching
+      errorThrown = false
+      try {
+        await api.fetchAndCache('https://example.com/api/fail-custom')
+      } catch (e) {
+        errorThrown = true
+      }
+      assert(errorThrown === true)
+      assert(fetchCount === 3)
+    }
+
+    // 4. Test Concurrent Calls (In-flight handling)
+    {
+      fetchCount = 0
+      const store = new Map()
+      const mockCache = {
+        get: async (key) => store.get(key),
+        set: async (key, val) => { store.set(key, val) },
+        delete: async (key) => { store.delete(key) }
+      }
+
+      const api = new API({ cache: mockCache })
+
+      // Start two concurrent calls
+      let p1 = api.fetchAndCache('https://example.com/api/concurrent')
+      let p2 = api.fetchAndCache('https://example.com/api/concurrent')
+
+      let [r1, r2] = await Promise.all([p1, p2])
+      assert(r1.count === 1)
+      assert(r2.count === 1)
+      assert(fetchCount === 1) // Should only fetch once!
+    }
+
+  } finally {
+    // Restore original fetch
+    globalThis.fetch = originalFetch
+  }
+}

--- a/test/cache.js
+++ b/test/cache.js
@@ -138,6 +138,20 @@ export async function testCache(c) {
       assert(fetchCount === 1) // Should only fetch once!
     }
 
+    // 5. Test prototype/property collision safety (e.g. key 'toString')
+    {
+      fetchCount = 0
+      const api = new API()
+      
+      let res1 = await api.fetchAndCache('toString')
+      assert(res1.count === 1)
+      assert(fetchCount === 1)
+
+      let res2 = await api.fetchAndCache('toString')
+      assert(res2.count === 1)
+      assert(fetchCount === 1)
+    }
+
   } finally {
     // Restore original fetch
     globalThis.fetch = originalFetch

--- a/test/test.js
+++ b/test/test.js
@@ -1,11 +1,12 @@
 import { TestKit } from 'testkit'
 import { errors } from './errors.js'
+import { testCache } from './cache.js'
 
 // create context:
 let c = {
   env: process.env,
 }
 // create TestKit
-let testKit = new TestKit(c, [errors])
+let testKit = new TestKit(c, [errors, testCache])
 // run
 await testKit.run()


### PR DESCRIPTION
This PR adds support for optional custom cache objects in API (like Map or treeder/state) that implement get, set, and delete functions. It also migrates the default cache to Map.